### PR TITLE
[#25] playerData speed 조정 시 BackGround Scroll speed 갱신 되도록 수정

### DIFF
--- a/Assets/Scenes/GB_scene.unity
+++ b/Assets/Scenes/GB_scene.unity
@@ -259,11 +259,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &700395285 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-  m_PrefabInstance: {fileID: 1903627521}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &828177418
 GameObject:
   m_ObjectHideFlags: 0
@@ -477,8 +472,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1575382568}
-  - {fileID: 700395285}
-  - {fileID: 1866240162}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -496,8 +489,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   backgrounds:
   - {fileID: 1575382568}
-  - {fileID: 700395285}
-  - {fileID: 1866240162}
 --- !u!1 &1575382567
 GameObject:
   m_ObjectHideFlags: 0
@@ -642,6 +633,7 @@ GameObject:
   - component: {fileID: 1578876857}
   - component: {fileID: 1578876856}
   - component: {fileID: 1578876855}
+  - component: {fileID: 1578876861}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -825,6 +817,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1578876861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1578876854}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f436d7d2a1d14eac90f6d11be645fa91, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1623991676
 GameObject:
   m_ObjectHideFlags: 0
@@ -909,205 +913,6 @@ Transform:
   m_Father: {fileID: 1281268817}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1866240160
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1866240162}
-  - component: {fileID: 1866240161}
-  - component: {fileID: 1866240164}
-  - component: {fileID: 1866240163}
-  m_Layer: 0
-  m_Name: BoosterItem
-  m_TagString: Item
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &1866240161
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866240160}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: e95c1ea151e91b546b342440541489a0, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.33, y: 2.75}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1866240162
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866240160}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -8.920534, y: 1.8954611, z: -0.5668519}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1383502252}
-  m_RootOrder: -1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &1866240163
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866240160}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.45833334
---- !u!114 &1866240164
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866240160}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0a4e3ca673ab4494da6df4f048c2a780, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _itemData: {fileID: 11400000, guid: 3def0ef420884cb47b62d3cea5fc708a, type: 2}
---- !u!1001 &1903627521
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1383502252}
-    m_Modifications:
-    - target: {fileID: 1256266911109666614, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_SortingOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_RootOrder
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -6.4705343
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.1054611
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.5668519
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3200065447319913391, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7228168036576194899, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
-      propertyPath: m_Name
-      value: HpItem
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b7c818684d6b76c4c9949a296e3e7383, type: 3}
 --- !u!1 &1979666766
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Map/BackgroundScrolling.cs
+++ b/Assets/Scripts/Map/BackgroundScrolling.cs
@@ -26,6 +26,7 @@ public class BackgroundScrolling : MonoBehaviour
 
     private void Update()
     {
+        _scrollSpeed = DataManager.Instance.LoadData().speed;
         ScrollBackground();
     }
     

--- a/Assets/Sprites/HpBar/blood_red_bar.png.meta
+++ b/Assets/Sprites/HpBar/blood_red_bar.png.meta
@@ -106,6 +106,19 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []

--- a/Assets/Sprites/HpBar/blood_red_bar_background.png.meta
+++ b/Assets/Sprites/HpBar/blood_red_bar_background.png.meta
@@ -106,6 +106,19 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []

--- a/Assets/Sprites/HpItem/HpItem.png.meta
+++ b/Assets/Sprites/HpItem/HpItem.png.meta
@@ -106,6 +106,19 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []


### PR DESCRIPTION
close #25
BackGroundScrolling
```
private void Update()
{
    _scrollSpeed = DataManager.Instance.LoadData().speed;
    ScrollBackground();
}
```

- BackGroundScrolling class에서 Update 메서드에 speed 갱신하는 코드 추가 완료했습니다
- 테스트 진행 시 정상적으로 속도 빨라지고 느려집니다